### PR TITLE
chore(renovate): enable rust-toolchain updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>Turbo87/renovate-config//rust/updateToolchain",
     "config:base"
   ],
   "baseBranches": ["develop"]


### PR DESCRIPTION
This happens mainly via inclusion of a third party snippet.

* https://github.com/renovatebot/renovate/issues/11488#issuecomment-961199038
* https://github.com/Turbo87/renovate-config/blob/7cc52ff9/rust/updateToolchain.json
* https://github.com/Turbo87/segelflug-classifieds/pull/144
* https://github.com/renovatebot/renovate/issues/20495
